### PR TITLE
Add Environment Variable for Output and Debug Print function plus cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 hook.so: hook.c
-	clang -shared -fPIC -ldl -o hook.so hook.c
-	#clang -shared -fPIC -lunwind -o hook.so hook.c
+	clang -shared -fPIC -ldl -Wall -Wextra -o hook.so hook.c
 
 clean:
 	rm -f hook.so

--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ info and unstripped binary names).
 
 ## Usage
 
-```
+```sh
 $ rm -f mallocs.log
 $ LD_PRELOAD=./hook.so clang -fuse-ld=lld hello_world.c
 $ c++filt < mallocs.txt > mallocs.demangled
 $ python flatten.py > mallocs.txt
 $ path/to/FlameGraph/flamegraph.pl mallocs.txt > mallocs.svg
+
+$ # use alternative output file, e.g. malloc.log
+$ MFG_OUTPUT=malloc.log LD_PRELOAD=./hook.so ...
 ```
 
 hook.so appends to a file named mallocs.txt. flatten.py reads a file named

--- a/flatten.py
+++ b/flatten.py
@@ -1,6 +1,6 @@
 import re
 
-with open("mallocs.demangled", "rU") as input_f:
+with open("mallocs.demangled", "r") as input_f:
     count = 0
     stack = []
     regex = re.compile("^malloc of ([0-9]+) bytes")

--- a/hook.c
+++ b/hook.c
@@ -20,7 +20,7 @@ void debug_print(const char *msg)
 #define debug_print(x)
 #endif
 
-#define OUTPUT_FILENAME_ENVVAR "MFG_OUTPUT"
+#define MFG_ENV_OUTPUT "MFG_OUTPUT"
 
 static int output_fd = -1;
 static void __attribute__((constructor)) init(void) {
@@ -28,7 +28,7 @@ static void __attribute__((constructor)) init(void) {
   debug_print("initialization\n");
 
   char* filename;
-  if (!(filename = getenv(OUTPUT_FILENAME_ENVVAR))) {
+  if (!(filename = getenv(MFG_ENV_OUTPUT))) {
     filename = "mallocs.log";
   }
 

--- a/hook.c
+++ b/hook.c
@@ -19,10 +19,19 @@ void debug_print(const char *msg)
 #define debug_print(x)
 #endif
 
+#define OUTPUT_FILENAME_ENVVAR "MFG_OUTPUT"
+
 static int output_fd = -1;
 static void __attribute__((constructor)) init(void) {
-  output_fd = open("mallocs.log", O_CREAT | O_APPEND | O_WRONLY,
+
   debug_print("initialization\n");
+
+  char* filename;
+  if (!(filename = getenv(OUTPUT_FILENAME_ENVVAR))) {
+    filename = "mallocs.log";
+  }
+
+  output_fd = open(filename, O_CREAT | O_APPEND | O_WRONLY,
       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
   if (output_fd == -1) exit(43);
 }


### PR DESCRIPTION
I've added an environment variable to specify the destination of the log. My use cases are MPI programs where each started process of the same program should write to an individual log. Besides that, I made some minor modifications, e.g. a debug function, and did come cleanup.

Hope you find those changes helpful.